### PR TITLE
Add Neo4j to Docker Compose network

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -30,6 +30,8 @@ Alternative automatic documentation with ReDoc (from the OpenAPI backend): http:
 
 PGAdmin, PostgreSQL web administration: http://localhost:5050
 
+Neo4j web administration: http://localhost:7474
+
 Flower, administration of Celery tasks: http://localhost:5555
 
 Traefik UI, to see how the routes are being handled by the proxy: http://localhost:8090

--- a/{{cookiecutter.project_slug}}/docker-compose.override.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.override.yml
@@ -31,6 +31,10 @@ services:
     ports:
       - "5050:5050"
 
+  neo4j:
+    environment:
+      - NEO4J_AUTH=none
+
   flower:
     ports:
       - "5555:5555"

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -105,7 +105,6 @@ services:
 
   neo4j:
     image: neo4j
-    platform: linux/amd64
     networks:
       - ${TRAEFIK_PUBLIC_NETWORK?Variable not set}
       - default

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -103,6 +103,48 @@ services:
         - traefik.http.routers.${STACK_NAME?Variable not set}-pgadmin-https.tls.certresolver=le
         - traefik.http.services.${STACK_NAME?Variable not set}-pgadmin.loadbalancer.server.port=5050
 
+  neo4j:
+    image: neo4j
+    platform: linux/amd64
+    networks:
+      - ${TRAEFIK_PUBLIC_NETWORK?Variable not set}
+      - default
+    ports:
+      - "6477:6477"
+      - "7474:7474"
+      - "7687:7687"
+    volumes:
+      - app-neo4j-data:/data
+      - app-neo4j-plugins:/plugins
+    env_file:
+      - .env
+    environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_AUTH=neo4j/neo4j
+      - NEO4J_dbms_default__advertised__address=0.0.0.0
+      - NEO4J_dbms_mode=SINGLE
+    deploy:
+      labels:
+        - traefik.enable=true
+        - traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK?Variable not set}
+        - traefik.constraint-label=${TRAEFIK_PUBLIC_TAG?Variable not set}
+        - traefik.http.routers.${STACK_NAME?Variable not set}-neo4j-http.rule=Host(`neo4j.${DOMAIN?Variable not set}`)
+        - traefik.http.routers.${STACK_NAME?Variable not set}-neo4j-http.entrypoints=http
+        - traefik.http.routers.${STACK_NAME?Variable not set}-neo4j-http.middlewares=${STACK_NAME?Variable not set}-https-redirect
+        - traefik.http.routers.${STACK_NAME?Variable not set}-neo4j-https.rule=Host(`neo4j.${DOMAIN?Variable not set}`)
+        - traefik.http.routers.${STACK_NAME?Variable not set}-neo4j-https.entrypoints=https
+        - traefik.http.routers.${STACK_NAME?Variable not set}-neo4j-https.tls=true
+        - traefik.http.routers.${STACK_NAME?Variable not set}-neo4j-https.tls.certresolver=le
+        - traefik.http.services.${STACK_NAME?Variable not set}-neo4j.loadbalancer.server.port=7474
+      replicas: 1
+      resources:
+        limits:
+          memory: 1024M
+        reservations:
+          memory: 500M
+      restart_policy:
+        condition: on-failure
+
   queue:
     image: rabbitmq:3
     # Using the below image instead is required to enable the "Broker" tab in the flower UI:
@@ -196,6 +238,8 @@ services:
 
 volumes:
   app-db-data:
+  app-neo4j-data:
+  app-neo4j-plugins:
 
 networks:
   traefik-public:


### PR DESCRIPTION
## Description

This PR will add a [Neo4j](https://neo4j.com) service to the Docker Compose network.

To try it out locally:

```sh
# Clone the repo
git clone git@github.com:whythawk/full-stack-fastapi-postgresql.git
cd ./full-stack-fastapi-postgresql

# Generate a sample project
bash ./scripts/dev-link.sh

# Start the Docker Compose network in the sample project
cd ./dev-link
docker-compose up
```

Then browse to the Neo4j dashboard at http://localhost:7474.

## Changes

- Pull [official Docker image](https://hub.docker.com/_/neo4j)
- Add Neo4j service to Docker Compose
- Register Neo4j storage volumes with Docker Compose
- Add Traefik labels for deployment
- Add overrides for local development

## Notes

The [Neo4j Docker image](https://hub.docker.com/_/neo4j) does not yet have multi-architecture support, so the image can only run on `x86_64` systems. If running on ARM processors (like Apple Silicon Macs), it is possible to specify the platform:

https://github.com/whythawk/full-stack-fastapi-postgresql/blob/b2f3d94f3d8ec4f9a72ac071ab02b5a67adab713/%7B%7Bcookiecutter.project_slug%7D%7D/docker-compose.yml#L106-L118

It is also possible to run the [experimental ARM images](https://hub.docker.com/r/neo4j/neo4j-arm64-experimental), but they are not yet tested.
