### PR TITLE
Use docker compose new version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ You can go to that directory with a full new project, edit files and test things
 ```console
 $ cd ./dev-fsfp/
 
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 It is outside of the project generator directory to let you add Git to it and compare versions and changes.

--- a/README.md
+++ b/README.md
@@ -143,16 +143,16 @@ The input variables, with their default values (some auto generated) are:
 
 Once the Cookiecutter script has completed, you will have a folder populated with the base project and all input variables customised. 
 
-Change into the project folder and run the `docker-compose` script to build the project containers:
+Change into the project folder and run the `docker compose` script to build the project containers:
 
 ```bash
-docker-compose build --no-cache
+docker compose build --no-cache
 ```
 
 And start them:
 
 ```bash
-docker-compose up -d 
+docker compose up -d 
 ```
 
 **NOTE:** I find that the **Nuxt** container does not run well in development mode, and does not refresh on changes. In particular, `nuxt/content` is very unpredictable in dev mode running in the container. It is far better to run the `frontend` outside of the container to take advantage of live refresh.
@@ -175,7 +175,7 @@ FastAPI `backend` updates will refresh automatically, but the `celeryworker` con
 If you like to do algorithmic development and testing in Jupyter Notebooks, then launch the `backend` terminal and start Jupyter as follows:
 
 ```bash
-docker-compose exec backend bash
+docker compose exec backend bash
 ```
 
 From the terminal:

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -15,7 +15,7 @@
 * Start the stack with Docker Compose:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 * Now you can open your browser and interact with these URLs:
@@ -41,13 +41,13 @@ Traefik UI, to see how the routes are being handled by the proxy: http://localho
 To check the logs, run:
 
 ```bash
-docker-compose logs
+docker compose logs
 ```
 
 To check the logs of a specific service, add the name of the service, e.g.:
 
 ```bash
-docker-compose logs backend
+docker compose logs backend
 ```
 
 If your Docker is not running in `localhost` (the URLs above wouldn't work) check the sections below on **Development with Docker Toolbox** and **Development with a custom IP**.
@@ -87,7 +87,7 @@ The changes to that file only affect the local development environment, not the 
 For example, the directory with the backend code is mounted as a Docker "host volume", mapping the code you change live to the directory inside the container. That allows you to test your changes right away, without having to build the Docker image again. It should only be done during development, for production, you should build the Docker image with a recent version of the backend code. But during development, it allows you to iterate very fast. Have in mind that if you have a syntax error and save the Python file, it will break and exit, and the container will stop. After that, you can restart the container by fixing the error and running again:
 
 ```console
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 There is also a commented out `command` override, you can uncomment it and comment the default one. It makes the backend container run a process that does "nothing", but keeps the container alive. That allows you to get inside your running container and execute commands inside, for example a Python interpreter to test installed dependencies, or start the development server that reloads when it detects changes, or start a Jupyter Notebook session.
@@ -95,13 +95,13 @@ There is also a commented out `command` override, you can uncomment it and comme
 To get inside the container with a `bash` session you can start the stack with:
 
 ```console
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 and then `exec` inside the running container:
 
 ```console
-$ docker-compose exec backend bash
+$ docker compose exec backend bash
 ```
 
 You should see an output like:
@@ -137,7 +137,7 @@ The `./backend/app` directory is mounted as a "host volume" inside the docker co
 You can rerun the test on live code:
 
 ```Bash
-docker-compose exec backend /app/tests-start.sh
+docker compose exec backend /app/tests-start.sh
 ```
 
 #### Test running stack
@@ -145,7 +145,7 @@ docker-compose exec backend /app/tests-start.sh
 If your stack is already up and you just want to run the tests, you can use:
 
 ```bash
-docker-compose exec backend /app/tests-start.sh
+docker compose exec backend /app/tests-start.sh
 ```
 
 That `/app/tests-start.sh` script just calls `pytest` after making sure that the rest of the stack is running. If you need to pass extra arguments to `pytest`, you can pass them to that command and they will be forwarded.
@@ -153,7 +153,7 @@ That `/app/tests-start.sh` script just calls `pytest` after making sure that the
 For example, to stop on first error:
 
 ```bash
-docker-compose exec backend bash /app/tests-start.sh -x
+docker compose exec backend bash /app/tests-start.sh -x
 ```
 
 #### Test Coverage
@@ -169,7 +169,7 @@ DOMAIN=backend sh ./scripts/test-local.sh --cov-report=html
 To run the tests in a running stack with coverage HTML reports:
 
 ```bash
-docker-compose exec backend bash /app/tests-start.sh --cov-report=html
+docker compose exec backend bash /app/tests-start.sh --cov-report=html
 ```
 
 ### Live development with Python Jupyter Notebooks
@@ -181,7 +181,7 @@ The `docker-compose.override.yml` file sends a variable `env` with a value `dev`
 So, you can enter into the running Docker container:
 
 ```bash
-docker-compose exec backend bash
+docker compose exec backend bash
 ```
 
 And use the environment variable `$JUPYTER` to run a Jupyter Notebook with everything configured to listen on the public port (so that you can use it from your browser).
@@ -222,7 +222,7 @@ Make sure you create a "revision" of your models and that you "upgrade" your dat
 * Start an interactive session in the backend container:
 
 ```console
-$ docker-compose exec backend bash
+$ docker compose exec backend bash
 ```
 
 * If you created a new model in `./backend/app/app/models/`, make sure to import it in `./backend/app/app/db/base.py`, that Python module (`base.py`) that imports all the models will be used by Alembic.
@@ -353,7 +353,7 @@ That variable will make your frontend communicate with that domain when interact
 After changing the two lines, you can re-start your stack with:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 and check all the corresponding available URLs in the section at the end.
@@ -577,7 +577,7 @@ If you change your mind and, for example, want to deploy everything to a differe
 
 #### Deployment Technical Details
 
-Building and pushing is done with the `docker-compose.yml` file, using the `docker-compose` command. The file `docker-compose.yml` uses the file `.env` with default environment variables. And the scripts set some additional environment variables as well.
+Building and pushing is done with the `docker-compose.yml` file, using the `docker compose` command. The file `docker-compose.yml` uses the file `.env` with default environment variables. And the scripts set some additional environment variables as well.
 
 The deployment requires using `docker stack` instead of `docker-swarm`, and it can't read environment variables or `.env` files. Because of that, the `deploy.sh` script generates a file `docker-stack.yml` with the configurations from `docker-compose.yml` and injecting the environment variables in it. And then uses it to deploy the stack.
 
@@ -591,11 +591,11 @@ TAG=${TAG?Variable not set} \
 # a default value of "production" if nothing else was passed
 FRONTEND_ENV=${FRONTEND_ENV-production?Variable not set} \
 # The actual comand that does the work: docker-compose
-docker-compose \
+docker compose \
 # Pass the file that should be used, setting explicitly docker-compose.yml avoids the
 # default of also using docker-compose.override.yml
 -f docker-compose.yml \
-# Use the docker-compose sub command named "config", it just uses the docker-compose.yml
+# Use the docker compose sub command named "config", it just uses the docker-compose.yml
 # file passed to it and prints their combined contents
 # Put those contents in a file "docker-stack.yml", with ">"
 config > docker-stack.yml
@@ -625,17 +625,17 @@ If you need to add more environments, for example, you could imagine using a cli
 
 ## Docker Compose files and env vars
 
-There is a main `docker-compose.yml` file with all the configurations that apply to the whole stack, it is used automatically by `docker-compose`.
+There is a main `docker-compose.yml` file with all the configurations that apply to the whole stack, it is used automatically by `docker compose`.
 
-And there's also a `docker-compose.override.yml` with overrides for development, for example to mount the source code as a volume. It is used automatically by `docker-compose` to apply overrides on top of `docker-compose.yml`.
+And there's also a `docker-compose.override.yml` with overrides for development, for example to mount the source code as a volume. It is used automatically by `docker compose` to apply overrides on top of `docker-compose.yml`.
 
 These Docker Compose files use the `.env` file containing configurations to be injected as environment variables in the containers.
 
-They also use some additional configurations taken from environment variables set in the scripts before calling the `docker-compose` command.
+They also use some additional configurations taken from environment variables set in the scripts before calling the `docker compose` command.
 
 It is all designed to support several "stages", like development, building, testing, and deployment. Also, allowing the deployment to different environments like staging and production (and you can add more environments very easily).
 
-They are designed to have the minimum repetition of code and configurations, so that if you need to change something, you have to change it in the minimum amount of places. That's why files use environment variables that get auto-expanded. That way, if for example, you want to use a different domain, you can call the `docker-compose` command with a different `DOMAIN` environment variable instead of having to change the domain in several places inside the Docker Compose files.
+They are designed to have the minimum repetition of code and configurations, so that if you need to change something, you have to change it in the minimum amount of places. That's why files use environment variables that get auto-expanded. That way, if for example, you want to use a different domain, you can call the `docker compose` command with a different `DOMAIN` environment variable instead of having to change the domain in several places inside the Docker Compose files.
 
 Also, if you want to have another deployment environment, say `preprod`, you just have to change environment variables, but you can keep using the same Docker Compose files.
 

--- a/{{cookiecutter.project_slug}}/scripts/build-push.sh
+++ b/{{cookiecutter.project_slug}}/scripts/build-push.sh
@@ -7,4 +7,4 @@ TAG=${TAG?Variable not set} \
 FRONTEND_ENV=${FRONTEND_ENV-production} \
 sh ./scripts/build.sh
 
-docker-compose -f docker-compose.yml push
+docker compose -f docker-compose.yml push

--- a/{{cookiecutter.project_slug}}/scripts/build.sh
+++ b/{{cookiecutter.project_slug}}/scripts/build.sh
@@ -5,6 +5,6 @@ set -e
 
 TAG=${TAG?Variable not set} \
 FRONTEND_ENV=${FRONTEND_ENV-production} \
-docker-compose \
+docker compose \
 -f docker-compose.yml \
 build

--- a/{{cookiecutter.project_slug}}/scripts/deploy.sh
+++ b/{{cookiecutter.project_slug}}/scripts/deploy.sh
@@ -7,7 +7,7 @@ DOMAIN=${DOMAIN?Variable not set} \
 TRAEFIK_TAG=${TRAEFIK_TAG?Variable not set} \
 STACK_NAME=${STACK_NAME?Variable not set} \
 TAG=${TAG?Variable not set} \
-docker-compose \
+docker compose \
 -f docker-compose.yml \
 config > docker-stack.yml
 

--- a/{{cookiecutter.project_slug}}/scripts/test-local.sh
+++ b/{{cookiecutter.project_slug}}/scripts/test-local.sh
@@ -3,13 +3,13 @@
 # Exit in case of error
 set -e
 
-docker-compose down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
+docker compose down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
 
 if [ $(uname -s) = "Linux" ]; then
     echo "Remove __pycache__ files"
     sudo find . -type d -name __pycache__ -exec rm -r {} \+
 fi
 
-docker-compose build
-docker-compose up -d
-docker-compose exec -T backend bash /app/tests-start.sh "$@"
+docker compose build
+docker compose up -d
+docker compose exec -T backend bash /app/tests-start.sh "$@"

--- a/{{cookiecutter.project_slug}}/scripts/test.sh
+++ b/{{cookiecutter.project_slug}}/scripts/test.sh
@@ -7,12 +7,12 @@ DOMAIN=backend \
 SMTP_HOST="" \
 TRAEFIK_PUBLIC_NETWORK_IS_EXTERNAL=false \
 INSTALL_DEV=true \
-docker-compose \
+docker compose \
 -f docker-compose.yml \
 config > docker-stack.yml
 
-docker-compose -f docker-stack.yml build
-docker-compose -f docker-stack.yml down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
-docker-compose -f docker-stack.yml up -d
-docker-compose -f docker-stack.yml exec -T backend bash /app/tests-start.sh "$@"
-docker-compose -f docker-stack.yml down -v --remove-orphans
+docker compose -f docker-stack.yml build
+docker compose -f docker-stack.yml down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
+docker compose -f docker-stack.yml up -d
+docker compose -f docker-stack.yml exec -T backend bash /app/tests-start.sh "$@"
+docker compose -f docker-stack.yml down -v --remove-orphans


### PR DESCRIPTION
Hi,
Love your fork!
`docker-compose` is now deprecated, and it is recommended to use `docker compose` instead (c.f. [stack overflow](https://stackoverflow.com/questions/66514436/difference-between-docker-compose-and-docker-compose))