### PR TITLE
Absolute path for mount point

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.override.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.override.yml
@@ -81,7 +81,7 @@ services:
     volumes:
       # https://stackoverflow.com/a/32785014
       - ./frontend:/app
-      - ./app/node_modules
+      - /app/node_modules
     build:
       context: ./frontend
       target: run-dev


### PR DESCRIPTION
Since 46447f9359a1472e10a715f7cb1ee934ec1464aa I  was unable to start docker and got the following errror:

`docker compose up`
```
[+] Running 2/0
 ⠿ Container bs-fastapi-nuxt-proxy-1     Created                                                                                                                                                                                                  0.0s
 ⠿ Container bs-fastapi-nuxt-queue-1     Created                                                                                                                                                                                                  0.0s
 ⠋ Container bs-fastapi-nuxt-db-1        Recreate                                                                                                                                                                                                 0.0s
 ⠋ Container bs-fastapi-nuxt-flower-1    Recreate                                                                                                                                                                                                 0.0s
 ⠋ Container bs-fastapi-nuxt-frontend-1  Recreate                                                                                                                                                                                                 0.0s
 ⠋ Container bs-fastapi-nuxt-neo4j-1     Recreate                                                                                                                                                                                                 0.0s
Error response from daemon: invalid mount config for type "volume": invalid mount path: 'app/node_modules' mount path must be absolute
```

This patch solves this issue, in the linked SO answer the second path is absolute too.
